### PR TITLE
Add webapp build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  webapp:
+    name: Build webapp
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/webapp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: src/webapp/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/src/webapp/src/components/datasets/DatasetsPage.tsx
+++ b/src/webapp/src/components/datasets/DatasetsPage.tsx
@@ -248,6 +248,7 @@ export function DatasetsPage() {
 						columns={columns}
 						data={filteredDatasets}
 						onRowClick={(dataset) => navigate(`/datasets/${dataset.id}`)}
+						emptyState={
 							<NoDataCard
 								icon={<FileText size={48} className="text-muted-foreground mb-4" />}
 								title={`No datasets found matching "${searchTerm}"`}


### PR DESCRIPTION
## Summary
- build the webapp on every pull request
- support manual workflow runs after the workflow reaches main
- fix malformed dataset empty-state JSX that prevented the existing build from succeeding

## Validation
- npm ci
- npm run build